### PR TITLE
Sdk format, net5 net6 net7 build target, test for new build target

### DIFF
--- a/src/AutoGrid.Tests/AutoGrid.Tests.csproj
+++ b/src/AutoGrid.Tests/AutoGrid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net40</TargetFrameworks>
+		<TargetFrameworks>net40;net5.0-windows7.0;net6.0-windows7.0;net7.0-windows7.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<UseWPF>true</UseWPF>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -19,12 +19,26 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'net40'">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
 		<PackageReference Include="FluentAssertions" Version="3.1.229" />
 		<PackageReference Include="Moq" Version="4.2.1507.118" />
 		<PackageReference Include="xunit" Version="1.9.2" />
 		<PackageReference Include="xunit.extensions" Version="1.9.2" />
 	</ItemGroup>
 
+	<ItemGroup Condition="$(TargetFramework) != 'net40'">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+		<PackageReference Include="FluentAssertions" Version="6.11.0" />
+		<PackageReference Include="Moq" Version="4.20.69" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<!--<PackageReference Include="xunit.extensions" Version="2.0.0" />-->
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Xunit.StaFact" Version="1.1.11" />
+	</ItemGroup>
+	
 	<ItemGroup>
 		<ProjectReference Include="..\AutoGrid\AutoGrid.csproj" />
 	</ItemGroup>

--- a/src/AutoGrid.Tests/AutoGrid.Tests.csproj
+++ b/src/AutoGrid.Tests/AutoGrid.Tests.csproj
@@ -1,84 +1,32 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D3DF2A55-FF73-4BC5-B1F4-2B71B3BC523A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AutoGrid.Tests</RootNamespace>
-    <AssemblyName>SpicyTaco.AutoGrid.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.3.1.229\lib\net40\FluentAssertions.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.3.1.229\lib\net40\FluentAssertions.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.extensions, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="describe_auto_grid.cs" />
-    <Compile Include="describe_stack_panel.cs" />
-    <Compile Include="FluentAssertionExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AutoGrid\AutoGrid.csproj">
-      <Project>{60440edd-cc03-479d-aa9d-7c6e53a57630}</Project>
-      <Name>AutoGrid</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net40</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<UseWPF>true</UseWPF>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'net40'">
+		<PackageReference Include="FluentAssertions" Version="3.1.229" />
+		<PackageReference Include="Moq" Version="4.2.1507.118" />
+		<PackageReference Include="xunit" Version="1.9.2" />
+		<PackageReference Include="xunit.extensions" Version="1.9.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\AutoGrid\AutoGrid.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/src/AutoGrid.Tests/FluentAssertionExtensions.cs
+++ b/src/AutoGrid.Tests/FluentAssertionExtensions.cs
@@ -3,6 +3,8 @@ using System.Windows.Controls;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Xunit;
+using Xunit.Extensions;
 
 namespace AutoGrid.Tests
 {
@@ -11,11 +13,16 @@ namespace AutoGrid.Tests
         // ReSharper disable once InconsistentNaming
         public class UIElementAssertions : ReferenceTypeAssertions<UIElement, UIElementAssertions>
         {
+#if NET5_0_OR_GREATER
+            public UIElementAssertions(UIElement value) : base(value)
+            {
+            }
+#else
             public UIElementAssertions(UIElement value)
             {
                 Subject = value;
             }
-
+#endif
             public AndConstraint<UIElementAssertions> BeAtGridPosition(
                 int expectedRow, int expectedColumn, string because = "", params object[] becauseArgs)
             {
@@ -30,12 +37,23 @@ namespace AutoGrid.Tests
                 return new AndConstraint<UIElementAssertions>(this);
             }
 
+
+#if NET5_0_OR_GREATER
+            protected override string Identifier => "FrameworkElement";
+#else
             protected override string Context => "FrameworkElement";
+#endif
         }
 
         public static UIElementAssertions Should(this UIElement subject)
         {
             return new UIElementAssertions(subject);
         }
+#if NET5_0_OR_GREATER
+        public static AndConstraint<ObjectAssertions> ShouldBeEquivalentTo<T>(this T t, T value)
+        {
+            return t.Should().BeEquivalentTo(t);
+        }
+#endif
     }
 }

--- a/src/AutoGrid.Tests/MyTestFactAttribute.cs
+++ b/src/AutoGrid.Tests/MyTestFactAttribute.cs
@@ -1,0 +1,14 @@
+﻿using Xunit;
+
+namespace AutoGrid.Tests
+{
+    public class MyTestFactAttribute :
+#if NET5_0_OR_GREATER
+        WpfFactAttribute
+#else
+        FactAttribute
+#endif
+    {
+
+    }
+}

--- a/src/AutoGrid.Tests/MyTestTheoryAttribute.cs
+++ b/src/AutoGrid.Tests/MyTestTheoryAttribute.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+using Xunit.Extensions;
+
+namespace AutoGrid.Tests
+{
+    public class MyTestTheoryAttribute :
+#if NET5_0_OR_GREATER
+        WpfTheoryAttribute
+#else
+        TheoryAttribute
+#endif
+    {
+
+    }
+}

--- a/src/AutoGrid.Tests/describe_auto_grid.cs
+++ b/src/AutoGrid.Tests/describe_auto_grid.cs
@@ -10,7 +10,7 @@ namespace AutoGrid.Tests
 {
     public class ParseShould
     {
-        [Fact]
+        [MyTestFact]
         public void HaveGridLengthOfThreeWhenParsingNumbers()
         {
             var result = AutoGrid.Parse("3,3,3,3");
@@ -18,7 +18,7 @@ namespace AutoGrid.Tests
                 x.Should().Be(new GridLength(3)));
         }
 
-        [Fact]
+        [MyTestFact]
         public void HaveGridLengthOfThreeWhenParsingStars()
         {
             var result = AutoGrid.Parse("*,*,*,*");
@@ -38,14 +38,14 @@ namespace AutoGrid.Tests
             _sut.PerformLayout();
         }
 
-        [Fact] public void HaveOneRow() => _sut.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void HaveTwoColumns() => _sut.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void HaveOneRow() => _sut.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void HaveTwoColumns() => _sut.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void MakeFirstChildRowIndexZero() => Grid.GetRow(_sut.Children[0]).Should().Be(0);
-        [Fact] public void MakeFirstChildColumnIndexZero() => Grid.GetColumn(_sut.Children[0]).Should().Be(0);
+        [MyTestFact] public void MakeFirstChildRowIndexZero() => Grid.GetRow(_sut.Children[0]).Should().Be(0);
+        [MyTestFact] public void MakeFirstChildColumnIndexZero() => Grid.GetColumn(_sut.Children[0]).Should().Be(0);
 
-        [Fact] public void MakeSecondChildRowIndexZero() => Grid.GetRow(_sut.Children[1]).Should().Be(0);
-        [Fact] public void MakeSecondChildColumnIndexOne() => Grid.GetColumn(_sut.Children[1]).Should().Be(1);
+        [MyTestFact] public void MakeSecondChildRowIndexZero() => Grid.GetRow(_sut.Children[1]).Should().Be(0);
+        [MyTestFact] public void MakeSecondChildColumnIndexOne() => Grid.GetColumn(_sut.Children[1]).Should().Be(1);
         private readonly AutoGrid _sut;
     }
 
@@ -61,14 +61,14 @@ namespace AutoGrid.Tests
             _sut.PerformLayout();
         }
 
-        [Fact] public void HaveOneRow() => _sut.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void HaveTwoColumns() => _sut.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void HaveOneRow() => _sut.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void HaveTwoColumns() => _sut.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void MakeFirstChildRowIndexZero() => Grid.GetRow(_sut.Children[0]).Should().Be(0);
-        [Fact] public void MakeFirstChildColumnIndexZero() => Grid.GetColumn(_sut.Children[0]).Should().Be(0);
+        [MyTestFact] public void MakeFirstChildRowIndexZero() => Grid.GetRow(_sut.Children[0]).Should().Be(0);
+        [MyTestFact] public void MakeFirstChildColumnIndexZero() => Grid.GetColumn(_sut.Children[0]).Should().Be(0);
 
-        [Fact] public void MakeSecondChildRowIndexZero() => Grid.GetRow(_sut.Children[1]).Should().Be(0);
-        [Fact] public void MakeSecondChildColumnIndexOne() => Grid.GetColumn(_sut.Children[1]).Should().Be(1);
+        [MyTestFact] public void MakeSecondChildRowIndexZero() => Grid.GetRow(_sut.Children[1]).Should().Be(0);
+        [MyTestFact] public void MakeSecondChildColumnIndexOne() => Grid.GetColumn(_sut.Children[1]).Should().Be(1);
         private readonly AutoGrid _sut;
     }
 
@@ -84,14 +84,14 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(2);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(1);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(1);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(0);
         private AutoGrid Subject;
     }
 
@@ -107,11 +107,11 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
         private AutoGrid Subject;
     }
 
@@ -126,11 +126,11 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
         private AutoGrid Subject;
     }
 
@@ -145,11 +145,11 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
         private AutoGrid Subject;
     }
 
@@ -168,26 +168,26 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
 
-        [Fact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
-        [Fact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
+        [MyTestFact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
 
-        [Fact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
-        [Fact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
 
-        [Fact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
-        [Fact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
+        [MyTestFact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
+        [MyTestFact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
 
-        [Fact] public void should_make_sixth_child_row_index_two() => Grid.GetRow(Subject.Children[5]).Should().Be(2);
-        [Fact] public void should_make_sixth_child_column_index_one() => Grid.GetColumn(Subject.Children[5]).Should().Be(1);
+        [MyTestFact] public void should_make_sixth_child_row_index_two() => Grid.GetRow(Subject.Children[5]).Should().Be(2);
+        [MyTestFact] public void should_make_sixth_child_column_index_one() => Grid.GetColumn(Subject.Children[5]).Should().Be(1);
         private AutoGrid Subject;
     }
 
@@ -206,26 +206,26 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(2);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
 
-        [Fact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(0);
-        [Fact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(2);
+        [MyTestFact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(2);
 
-        [Fact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
-        [Fact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(0);
+        [MyTestFact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(0);
 
-        [Fact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(1);
-        [Fact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(1);
+        [MyTestFact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(1);
+        [MyTestFact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(1);
 
-        [Fact] public void should_make_sixth_child_row_index_two() => Grid.GetRow(Subject.Children[5]).Should().Be(1);
-        [Fact] public void should_make_sixth_child_column_index_one() => Grid.GetColumn(Subject.Children[5]).Should().Be(2);
+        [MyTestFact] public void should_make_sixth_child_row_index_two() => Grid.GetRow(Subject.Children[5]).Should().Be(1);
+        [MyTestFact] public void should_make_sixth_child_column_index_one() => Grid.GetColumn(Subject.Children[5]).Should().Be(2);
         private AutoGrid Subject;
     }
 
@@ -245,23 +245,23 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
 
-        [Fact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
-        [Fact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
+        [MyTestFact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
 
-        [Fact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
-        [Fact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
 
-        [Fact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
-        [Fact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
+        [MyTestFact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
+        [MyTestFact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
         private AutoGrid Subject;
     }
 
@@ -284,14 +284,14 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void ShouldHaveTwoRows() => Subject.RowDefinitions.Count.Should().Be(2);
-        [Fact] public void ShouldHaveThreeColumns() => Subject.ColumnDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void ShouldHaveTwoRows() => Subject.RowDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void ShouldHaveThreeColumns() => Subject.ColumnDefinitions.Count.Should().Be(3);
 
-        [Fact] public void ShouldHaveFirstChildAtZeroZero() => Subject.Children[0].Should().BeAtGridPosition(0, 0);
-        [Fact] public void ShouldHaveSecondChildAtOneZero() => Subject.Children[1].Should().BeAtGridPosition(0, 1);
-        [Fact] public void ShouldHaveThirdChildAtOneZero() => Subject.Children[2].Should().BeAtGridPosition(0, 2);
-        [Fact] public void ShouldHaveForthChildAtOneZero() => Subject.Children[3].Should().BeAtGridPosition(1, 1);
-        [Fact] public void ShouldHaveFifthChildAtOneZero() => Subject.Children[4].Should().BeAtGridPosition(1, 2);
+        [MyTestFact] public void ShouldHaveFirstChildAtZeroZero() => Subject.Children[0].Should().BeAtGridPosition(0, 0);
+        [MyTestFact] public void ShouldHaveSecondChildAtOneZero() => Subject.Children[1].Should().BeAtGridPosition(0, 1);
+        [MyTestFact] public void ShouldHaveThirdChildAtOneZero() => Subject.Children[2].Should().BeAtGridPosition(0, 2);
+        [MyTestFact] public void ShouldHaveForthChildAtOneZero() => Subject.Children[3].Should().BeAtGridPosition(1, 1);
+        [MyTestFact] public void ShouldHaveFifthChildAtOneZero() => Subject.Children[4].Should().BeAtGridPosition(1, 2);
         private AutoGrid Subject;
     }
 
@@ -314,14 +314,14 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void ShouldHaveTwoRows() => Subject.RowDefinitions.Count.Should().Be(2);
-        [Fact] public void ShouldHaveThreeColumns() => Subject.ColumnDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void ShouldHaveTwoRows() => Subject.RowDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void ShouldHaveThreeColumns() => Subject.ColumnDefinitions.Count.Should().Be(3);
 
-        [Fact] public void ShouldHaveFirstChildAtZeroZero() => Subject.Children[0].Should().BeAtGridPosition(0,0);
-        [Fact] public void ShouldHaveSecondChildAtOneZero() => Subject.Children[1].Should().BeAtGridPosition(1,0);
-        [Fact] public void ShouldHaveThirdChildAtOneZero() => Subject.Children[2].Should().BeAtGridPosition(1,1);
-        [Fact] public void ShouldHaveForthChildAtOneZero() => Subject.Children[3].Should().BeAtGridPosition(1,2);
-        [Fact] public void ShouldHaveFifthChildAtOneZero() => Subject.Children[4].Should().BeAtGridPosition(1,3);
+        [MyTestFact] public void ShouldHaveFirstChildAtZeroZero() => Subject.Children[0].Should().BeAtGridPosition(0,0);
+        [MyTestFact] public void ShouldHaveSecondChildAtOneZero() => Subject.Children[1].Should().BeAtGridPosition(1,0);
+        [MyTestFact] public void ShouldHaveThirdChildAtOneZero() => Subject.Children[2].Should().BeAtGridPosition(1,1);
+        [MyTestFact] public void ShouldHaveForthChildAtOneZero() => Subject.Children[3].Should().BeAtGridPosition(1,2);
+        [MyTestFact] public void ShouldHaveFifthChildAtOneZero() => Subject.Children[4].Should().BeAtGridPosition(1,3);
 
         private AutoGrid Subject;
     }
@@ -340,23 +340,23 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
 
-        [Fact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
-        [Fact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_make_third_child_row_index_one() => Grid.GetRow(Subject.Children[2]).Should().Be(1);
+        [MyTestFact] public void should_make_third_child_column_index_zero() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
 
-        [Fact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
-        [Fact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_row_index_one() => Grid.GetRow(Subject.Children[3]).Should().Be(1);
+        [MyTestFact] public void should_make_forth_child_column_index_one() => Grid.GetColumn(Subject.Children[3]).Should().Be(1);
 
-        [Fact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
-        [Fact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
+        [MyTestFact] public void should_make_fifth_child_row_index_two() => Grid.GetRow(Subject.Children[4]).Should().Be(2);
+        [MyTestFact] public void should_make_fifth_child_column_index_zero() => Grid.GetColumn(Subject.Children[4]).Should().Be(0);
         private AutoGrid Subject;
     }
 
@@ -377,17 +377,17 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_two_columns() => Subject.ColumnDefinitions.Count.Should().Be(2);
 
-        [Fact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
-        [Fact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_row_index_zero() => Grid.GetRow(Subject.Children[0]).Should().Be(0);
+        [MyTestFact] public void should_make_first_child_column_index_zero() => Grid.GetColumn(Subject.Children[0]).Should().Be(0);
 
-        [Fact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
-        [Fact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
+        [MyTestFact] public void should_make_second_child_row_index_zero() => Grid.GetRow(Subject.Children[1]).Should().Be(0);
+        [MyTestFact] public void should_make_second_child_column_index_one() => Grid.GetColumn(Subject.Children[1]).Should().Be(1);
 
-        [Fact] public void should_not_change_third_child_row_index() => Grid.GetRow(Subject.Children[2]).Should().Be(0);
-        [Fact] public void should_not_change_third_child_column_index() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_not_change_third_child_row_index() => Grid.GetRow(Subject.Children[2]).Should().Be(0);
+        [MyTestFact] public void should_not_change_third_child_column_index() => Grid.GetColumn(Subject.Children[2]).Should().Be(0);
         private AutoGrid Subject;
     }
 
@@ -406,12 +406,12 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_three_rows() => Subject.RowDefinitions.Count.Should().Be(3);
-        [Fact] public void should_have_one_column() => Subject.ColumnDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_three_rows() => Subject.RowDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_one_column() => Subject.ColumnDefinitions.Count.Should().Be(1);
 
-        [Fact] public void should_make_first_child_row_height_auto() => Subject.RowDefinitions[0].Height.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_second_child_row_height_auto() => Subject.RowDefinitions[1].Height.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_third_child_row_height_star() => Subject.RowDefinitions[2].Height.Should().Be(new GridLength(1, GridUnitType.Star));
+        [MyTestFact] public void should_make_first_child_row_height_auto() => Subject.RowDefinitions[0].Height.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_second_child_row_height_auto() => Subject.RowDefinitions[1].Height.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_third_child_row_height_star() => Subject.RowDefinitions[2].Height.Should().Be(new GridLength(1, GridUnitType.Star));
         private AutoGrid Subject;
     }
 
@@ -430,12 +430,12 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_three_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_three_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
 
-        [Fact] public void should_make_first_child_column_width_auto() => Subject.ColumnDefinitions[0].Width.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_second_child_column_width_auto() => Subject.ColumnDefinitions[1].Width.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_third_child_column_width_star() => Subject.ColumnDefinitions[2].Width.Should().Be(new GridLength(1, GridUnitType.Star));
+        [MyTestFact] public void should_make_first_child_column_width_auto() => Subject.ColumnDefinitions[0].Width.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_second_child_column_width_auto() => Subject.ColumnDefinitions[1].Width.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_third_child_column_width_star() => Subject.ColumnDefinitions[2].Width.Should().Be(new GridLength(1, GridUnitType.Star));
         private AutoGrid Subject;
     }
 
@@ -455,12 +455,12 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_three_rows() => Subject.RowDefinitions.Count.Should().Be(3);
-        [Fact] public void should_have_one_column() => Subject.ColumnDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_three_rows() => Subject.RowDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_one_column() => Subject.ColumnDefinitions.Count.Should().Be(1);
 
-        [Fact] public void should_make_first_child_row_height_auto() => Subject.RowDefinitions[0].Height.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_second_child_row_height_auto() => Subject.RowDefinitions[1].Height.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_third_child_row_height_star() => Subject.RowDefinitions[2].Height.Should().Be(new GridLength(1, GridUnitType.Star));
+        [MyTestFact] public void should_make_first_child_row_height_auto() => Subject.RowDefinitions[0].Height.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_second_child_row_height_auto() => Subject.RowDefinitions[1].Height.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_third_child_row_height_star() => Subject.RowDefinitions[2].Height.Should().Be(new GridLength(1, GridUnitType.Star));
         private AutoGrid Subject;
     }
 
@@ -480,12 +480,12 @@ namespace AutoGrid.Tests
             Subject.PerformLayout();
         }
 
-        [Fact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
-        [Fact] public void should_have_three_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
+        [MyTestFact] public void should_have_one_row() => Subject.RowDefinitions.Count.Should().Be(1);
+        [MyTestFact] public void should_have_three_columns() => Subject.ColumnDefinitions.Count.Should().Be(3);
 
-        [Fact] public void should_make_first_child_column_width_auto() => Subject.ColumnDefinitions[0].Width.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_second_child_column_width_auto() => Subject.ColumnDefinitions[1].Width.Should().Be(GridLength.Auto);
-        [Fact] public void should_make_third_child_column_width_star() => Subject.ColumnDefinitions[2].Width.Should().Be(new GridLength(1, GridUnitType.Star));
+        [MyTestFact] public void should_make_first_child_column_width_auto() => Subject.ColumnDefinitions[0].Width.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_second_child_column_width_auto() => Subject.ColumnDefinitions[1].Width.Should().Be(GridLength.Auto);
+        [MyTestFact] public void should_make_third_child_column_width_star() => Subject.ColumnDefinitions[2].Width.Should().Be(new GridLength(1, GridUnitType.Star));
         private AutoGrid Subject;
     }
 }

--- a/src/AutoGrid.Tests/describe_stack_panel.cs
+++ b/src/AutoGrid.Tests/describe_stack_panel.cs
@@ -10,7 +10,7 @@ namespace AutoGrid.Tests
 {
     public class StackPanelMeasureShould
     {
-        [Fact]
+        [MyTestFact]
         public void HaveDesiredSizeOfZeroWhenNoChildren()
         {
             var subject = new StackPanel();
@@ -18,7 +18,7 @@ namespace AutoGrid.Tests
             subject.DesiredSize.ShouldBeEquivalentTo(new Size());
         }
 
-        [Fact]
+        [MyTestFact]
         public void HaveDesiredSizeOfOneHundredWithChild()
         {
             var subject = new StackPanel();
@@ -32,7 +32,7 @@ namespace AutoGrid.Tests
             subject.DesiredSize.ShouldBeEquivalentTo(new Size(100, 100));
         }
 
-        [Theory]
+        [MyTestTheory]
         [InlineData(1, Orientation.Vertical, 100, 100)]
         [InlineData(3, Orientation.Vertical, 100, 300)]
         [InlineData(3, Orientation.Horizontal, 300, 100)]
@@ -48,7 +48,7 @@ namespace AutoGrid.Tests
             subject.DesiredSize.ShouldBeEquivalentTo(new Size(expectedWidth, expectedHeight));
         }
 
-        [Fact]
+        [MyTestFact]
         public void SplitSpaceWhenTwoFills()
         {
             var subject = new StackPanel();

--- a/src/AutoGrid.Tests/packages.config
+++ b/src/AutoGrid.Tests/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FluentAssertions" version="3.1.229" targetFramework="net40" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net40" />
-  <package id="xunit" version="1.9.2" targetFramework="net40" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
-</packages>

--- a/src/AutoGrid/AutoGrid.csproj
+++ b/src/AutoGrid/AutoGrid.csproj
@@ -1,62 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{60440EDD-CC03-479D-AA9D-7C6E53A57630}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AutoGrid</RootNamespace>
-    <AssemblyName>SpicyTaco.AutoGrid</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AutoGrid.cs" />
-    <Compile Include="DependencyHelper.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StackPanel.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="AutoGrid.nuspec" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFrameworks>net40</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<UseWPF>true</UseWPF>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/src/AutoGrid/AutoGrid.csproj
+++ b/src/AutoGrid/AutoGrid.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFrameworks>net40</TargetFrameworks>
+		<TargetFrameworks>net40;net5.0-windows7.0;net6.0-windows7.0;net7.0-windows7.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<UseWPF>true</UseWPF>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/AutoGridSample/AutoGridSample.csproj
+++ b/src/AutoGridSample/AutoGridSample.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>net40</TargetFrameworks>
+		<TargetFrameworks>net40;net5.0-windows7.0;net6.0-windows7.0;net7.0-windows7.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<UseWPF>true</UseWPF>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/AutoGridSample/AutoGridSample.csproj
+++ b/src/AutoGridSample/AutoGridSample.csproj
@@ -1,107 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9E27C0EB-65CA-4C87-AD31-88AB40458BEE}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AutoGridSample</RootNamespace>
-    <AssemblyName>SpicyTaco.AutoGridSample</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <AppDesigner Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AutoGrid\AutoGrid.csproj">
-      <Project>{60440edd-cc03-479d-aa9d-7c6e53a57630}</Project>
-      <Name>AutoGrid</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFrameworks>net40</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<UseWPF>true</UseWPF>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\AutoGrid\AutoGrid.csproj" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Change Log
- Upgrade to `NET SDK`  
- Add TargetFrameworks: `net5.0-windows7.0` `net6.0-windows7.0` `net7.0-windows7.0`  
- Make test work for Net5 and higher  

# Test
![image](https://github.com/SpicyTaco/SpicyTaco.AutoGrid/assets/13986296/8816ed49-ee44-4bfc-a80c-a51c4bffdd8a)
<details>
  <summary>Why test count  difference</summary>

<img src="https://github.com/SpicyTaco/SpicyTaco.AutoGrid/assets/13986296/92da4879-4f9e-45cd-adc7-edb096b4daac"  style="height: 100px; width:100px;"/>  
<br/>
and  
<br/>
<img src="https://github.com/SpicyTaco/SpicyTaco.AutoGrid/assets/13986296/4cb535e0-ee79-488d-b80a-ddbdb3c9d18d"  style="height: 100px; width:100px;"/>

</details>

# AutoGridSample 
net7.0-windows7.0
![image](https://github.com/SpicyTaco/SpicyTaco.AutoGrid/assets/13986296/ff88aa44-a706-4ef3-8a28-aed5fccd29fc)  
![image](https://github.com/SpicyTaco/SpicyTaco.AutoGrid/assets/13986296/47429b85-9198-445f-8b12-fef5840bb706)

